### PR TITLE
Adjusted package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "dist/credentials/PersonioOAuth2Api.credentials.js"
     ],
     "nodes": [
-      "dist/nodes/Personio/Personio.node.ts"
+      "dist/nodes/Personio/Personio.node.js"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
**I'm getting the following error message, when trying to install the module in n8n:** 
"Error installing new package
Error loading package "n8n-nodes-personio" :The specified package could not be loaded Cause: Cannot find module '/home/node/.n8n/nodes/node_modules/n8n-nodes-personio/dist/nodes/Personio/Personio.node.ts' Require stack: - /usr/local/lib/node_modules/n8n/node_modules/n8n-core/dist/nodes-loader/load-class-in-isolation.js - /usr/local/lib/node_modules/n8n/node_modules/n8n-core/dist/nodes-loader/directory-loader.js - /usr/local/lib/node_modules/n8n/node_modules/n8n-core/dist/nodes-loader/index.js - /usr/local/lib/node_modules/n8n/node_modules/n8n-core/dist/index.js - /usr/local/lib/node_modules/n8n/dist/config/index.js - /usr/local/lib/node_modules/n8n/dist/security-audit/security-audit.service.js - /usr/local/lib/node_modules/n8n/dist/commands/audit.js - /usr/local/lib/node_modules/n8n/node_modules/@oclif/core/lib/module-loader.js - /usr/local/lib/node_modules/n8n/node_modules/@oclif/core/lib/help/index.js - /usr/local/lib/node_modules/n8n/node_modules/@oclif/core/lib/errors/handle.js - /usr/local/lib/node_modules/n8n/node_modules/@oclif/core/lib/errors/index.js - /usr/local/lib/node_modules/n8n/node_modules/@oclif/core/lib/config/config.js - /usr/local/lib/node_modules/n8n/node_modules/@oclif/core/lib/config/index.js - /usr/local/lib/node_modules/n8n/node_modules/@oclif/core/lib/command.js - /usr/local/lib/node_modules/n8n/node_modules/@oclif/core/lib/index.js"

**I've modified the package.json to solve the problem:**

The path specified in the n8n.nodes array was changed. 

- Old path: "dist/nodes/Personio/Personio.node.ts"
- New path: "dist/nodes/Personio/Personio.node.js"

**Reason:** The build process compiles TypeScript (.ts) files into JavaScript (.js) files located in the dist directory. The original path incorrectly pointed to the source file instead of the compiled output file that n8n needs to load.